### PR TITLE
(Untested) Fix for statistic tables errors

### DIFF
--- a/settings.pl
+++ b/settings.pl
@@ -31,6 +31,7 @@ $g_index_url = "$schema_base;f=admin/sql/CreateIndexes.sql;hb=master";
 $g_pk_url = "$schema_base;f=admin/sql/CreatePrimaryKeys.sql;hb=master";
 $g_func_url = "$schema_base;f=admin/sql/CreateFunctions.sql;hb=master";
 $g_pending_url = "$schema_base;f=admin/sql/ReplicationSetup.sql;hb=master";
+$g_stats_url = "$schema_base;f=admin/sql/statistics/CreateTables.sql";
 
 # Replications URL
 $g_rep_host = "ftp.musicbrainz.org";


### PR DESCRIPTION
Add admin/sql/statistics/CreateTables.sql to a new variable of settings.pl as a first step for supporting recent MusicBrainz schema changes and handle misnamed files from mbdump directory.
