### PR TITLE
Handle statistic tables on data load

### DIFF
--- a/backend/mysql.pl
+++ b/backend/mysql.pl
@@ -119,8 +119,13 @@ sub backend_mysql_load_data {
 		{
        			mbz_do_sql("ALTER TABLE `$table` DROP COLUMN dummycolumn");
 		}
+		
+		if(substr($table, 0, 11) eq "statistics.")
+		{
+			$table = substr($table, 11, strlen($table) - 11);
+		}
 
-		print "\n" . localtime() . ": Loading data into '$file' ($i of $count)...\n";
+		print "\n" . localtime() . ": Loading data into '$table' ($i of $count)...\n";
 		mbz_do_sql("LOAD DATA LOCAL INFILE 'mbdump/$file' INTO TABLE `$table` ".
 		           "FIELDS TERMINATED BY '\\t' ".
 		           "ENCLOSED BY '' ".


### PR DESCRIPTION
mbdump-stats.tar.bz2 now append "statistics." to table names:

root@i3-mysql-ngs:/opt/mbzdb# tar tvjf replication/mbdump-stats.tar.bz2 
-rw-r--r-- musicbrainz/musicbrainz 29 2013-03-02 01:30 TIMESTAMP
-rw-r--r-- musicbrainz/musicbrainz 15818 2013-03-02 02:31 COPYING
-rw-r--r-- musicbrainz/musicbrainz   213 2013-03-02 02:31 README
-rw-r--r-- musicbrainz/musicbrainz     6 2013-03-02 02:20 REPLICATION_SEQUENCE
-rw-r--r-- musicbrainz/musicbrainz     3 2013-03-02 01:30 SCHEMA_SEQUENCE
-rw-r--r-- musicbrainz/musicbrainz 77151050 2013-03-02 02:20 mbdump/statistics.statistic
-rw-r--r-- musicbrainz/musicbrainz     7248 2013-03-02 02:20 mbdump/statistics.statistic_event
root@i3-mysql-ngs:/opt/mbzdb#

This patch would remove it from the table name before issuing the LOAD DATA INFILE.
